### PR TITLE
Change to different function length check

### DIFF
--- a/lib/ConnectSequence.js
+++ b/lib/ConnectSequence.js
@@ -234,9 +234,7 @@ function appendListIf (filter, middlewares) {
  * @returns {Boolean}
  */
 function isErrorHandler (cb) {
-  var str = cb.toString()
-  var args = str.split('(')[1].split(')')[0].split(',')
-  return args.length === 4
+  return cb.length === 4
 }
 
 /**


### PR DESCRIPTION
Today as I was using connect-sequence, I was hit with an exception:

```
[ integration]       ERROR: Extra: (none), message: str.split is not a function, stack: TypeError: str.split is not a function
[ integration]           at isErrorHandler (/Users/levibostian/code/ExpressjsBlanky/node_modules/connect-sequence/lib/ConnectSequence.js:238:18)
[ integration]           at nextHandler (/Users/levibostian/code/ExpressjsBlanky/node_modules/connect-sequence/lib/ConnectSequence.js:91:13)
[ integration]           at ConnectSequence.run (/Users/levibostian/code/ExpressjsBlanky/node_modules/connect-sequence/lib/ConnectSequence.js:67:22)
```

This crash occurred at the code: 

```
function isErrorHandler (cb) {
  var str = cb.toString()
  var args = str.split('(')[1].split(')')[0].split(',')
  return args.length === 4
}
```

After debugging, I realized that `cb` is an instance of an [express-validator](https://github.com/express-validator/express-validator) middleware. For some reason, when calling `cb.toString()` the result was not a string, but another function according to the debugger. 

So, after doing some research on "how to count the number of parameters in a function", I found this method that I used in this PR. 

After running my unit and integration tests on my application, everything seems to work well without the crash. I also checked the debugger and `cb.length` returns an integer successfully. I expected a length of 3 for my express validator middleware and that is what successfully was returned back. 